### PR TITLE
add clean method

### DIFF
--- a/lib/dml_config.js
+++ b/lib/dml_config.js
@@ -28,7 +28,10 @@ function createDefault() {
         defaultRemoteServerPackageFileExtension: ".tar.gz",
         unzipExecutablePath: '/usr/bin/unzip',
         npmSkipInstall: false,
-        lockOwner: {id:'DynamicModuleLoader'}
+        lockOwner: {id:'DynamicModuleLoader'},
+        cleanUpEnabled: false,
+        cleanUpExecutablePath: '',
+        cleanUpScriptArguments: ''
     };
 }
 

--- a/lib/dynamic_module_loader.js
+++ b/lib/dynamic_module_loader.js
@@ -461,14 +461,15 @@ var DynamicModuleLoader = new JS.Class(
                     {
                         if (code === 0)
                         {
-                            // Hah!  Success!
-                            self.emit(self.events.moduleInstalled, moduleName, moduleInstallationPath,
-                                      callbacks.createCountedCallback(
-                                          self.listeners(self.events.moduleInstalled).length,
-                                          wrap(function ()
-                                               {
-                                                   loadDownloadedModule(moduleInstallationPath);
-                                               })));
+                            if (self.settings.cleanUpEnabled)
+                            {
+                                var future = self.clean();
+                                future.when(emitModuleInstalledEvent);
+                            }
+                            else
+                            {
+                                emitModuleInstalledEvent();
+                            }
                         }
                         else
                         {
@@ -482,6 +483,18 @@ var DynamicModuleLoader = new JS.Class(
 
                             unlockAndFulfill(new Error(message), undefined);
                         }
+                    }
+
+                    function emitModuleInstalledEvent()
+                    {
+                        // Hah!  Success!
+                        self.emit(self.events.moduleInstalled, moduleName, moduleInstallationPath,
+                            callbacks.createCountedCallback(
+                                self.listeners(self.events.moduleInstalled).length,
+                                wrap(function ()
+                                {
+                                    loadDownloadedModule(moduleInstallationPath);
+                                })));
                     }
                 }
 
@@ -731,6 +744,57 @@ var DynamicModuleLoader = new JS.Class(
             }
         },
 
+        /**
+         * Clean up method called if activated in the dynamic loader configuration.
+         * The method is quite minimalist but it can be overriden by the client if it wants to improve it.
+         * By default it calls an executable, if the path is provided in the configuration.
+         * The executable has to be implemented and provided by the client as well.
+         */
+        clean: function()
+        {
+            var self = this;
+            var future = new Future();
+            fs.exists(self.settings.cleanUpExecutablePath, function (exists)
+            {
+                logger.debug("trying to call cleaning executable");
+                if (exists)
+                {
+                    var cleanUpArgs = self.settings.cleanUpScriptArguments.split(",");
+                    var cleanup = spawn(self.settings.cleanUpExecutablePath, cleanUpArgs);
+
+                    cleanup.stderr.on('data', function (data)
+                    {
+                        logger.error('clean up stderr: ' + data);
+                    });
+
+                    // End the response on zip exit
+                    cleanup.on('exit', function (code)
+                    {
+                        if (code === 0)
+                        {
+                            logger.debug("eh eh! the clean up script worked fine");
+                            // the clean up worked fine
+                            future.fulfill(undefined);
+                        }
+                        else
+                        {
+                            var message = util.format("Error with code %d while calling clean up script %s.  See log for " +
+                                "details.",
+                                code,
+                                self.settings.unzipExecutablePath);
+                            logger.error(message);
+                            future.fulfill(new Error(message), undefined);
+                        }
+                    });
+                }
+                else
+                {
+                    logger.warn(util.format("Unable to find clean up script %s", self.settings.cleanUpExecutablePath));
+                    future.fulfill(undefined);
+                }
+            });
+            return future;
+        },
 
         /**
          * Downloads the file specified in the sourceUrl to the targetFilePath. This version

--- a/test/dml_config_test.js
+++ b/test/dml_config_test.js
@@ -25,6 +25,9 @@ describe('DynamicModuleLoaderConfigTest', function ()
             assert.equal(config.downloadLockTimeout, 30000, 'downloadLockTimeout');
             assert.equal(config.defaultRemoteServerPackageFileExtension, '.tar.gz', 'defaultRemoteServerPackageFileExtension');
             assert.equal(config.unzipExecutablePath, '/usr/bin/unzip', 'unzipExecutablePath', 'npmSkipInstall');
+            assert.equal(config.cleanUpEnabled, false);
+            assert.equal(config.cleanUpExecutablePath, '');
+            assert.equal(config.cleanUpScriptArguments, '');
             assert.equal(config.npmSkipInstall, false);
             assert.deepEqual(config.lockOwner, {id:'DynamicModuleLoader'}, 'lockOwner');
 

--- a/test/resources/cleanUp.sh
+++ b/test/resources/cleanUp.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+touch cleanup.log


### PR DESCRIPTION
add a clean up method that can be either overridden by the client or associated with a clean up executable given in the configuration. 

KQuery will use it to clean up in run-time the old packages and Hops will be able to implement the strategy they want in a bash script
